### PR TITLE
Use pkg_config method to set CFLAGS LDFLAGS correctly

### DIFF
--- a/ext/vterm/extconf.rb
+++ b/ext/vterm/extconf.rb
@@ -1,8 +1,7 @@
 require 'mkmf'
 
+pkg_config('vterm')
 dir_config('vterm')
 have_header('vterm.h')
 have_library('vterm', 'vterm_new')
 create_makefile('vterm')
-$CFLAGS = "#{`pkg-config --cflags vterm`} -Werror"
-$LDFLAGS = `pkg-config --libs vterm`


### PR DESCRIPTION
In my new mac(M2), `rake compile` failed.

After changing `extconf.rb` like this, `rake compile` succeed.
```diff
+ $CFLAGS = "#{`pkg-config --cflags vterm`} -Werror".delete("\n")
+ $LDFLAGS = `pkg-config --libs vterm`
  create_makefile('vterm')
- $CFLAGS = "#{`pkg-config --cflags vterm`} -Werror"
- $LDFLAGS = `pkg-config --libs vterm`
```

These are the problems.
```ruby
create_makefile('vterm')
# Setting global variable after creating makefile has no effect.
$CFLAGS = "#{`pkg-config --cflags vterm`} -Werror" # Output of pkg-config has trailing \n, need to remove it
$LDFLAGS = `pkg-config --libs vterm`
```

Fortunately, we don't have to set `$CFLAGS`, `$LDFLAGS` and other global variables manually. `pkg_config('vterm')` will do it.